### PR TITLE
Adding CheckPageSpeedInsightsCommand to Services.yaml

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -132,3 +132,9 @@ services:
         additionalCssClasses: 'dashboard-item--chart'
         height: 'large'
         width: 'large'
+        
+  Haassie\PageSpeedInsights\Command\CheckPageSpeedInsightsCommand:
+    tags:
+      - name: console.command
+        command: 'pagespeedinsights:run'
+        description: 'Check pages on PageSpeed Insight'


### PR DESCRIPTION
For V11 compatibility the registration has to be placed in Services.yaml
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Deprecation-89139-ConsoleCommandsConfigurationFormatCommandsPhp.html